### PR TITLE
Add a new option: replace. When typing a password, it will show the specified string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Default options:
     'retry': true,
     // Do not print what the user types
     'silent': false,
+    // Replace each character with the specified string when 'silent' is true
+    'replace': '',
     // Input and output streams to read and write to
     'input': process.stdin,
     'output': process.stdout
@@ -165,7 +167,7 @@ The available options are the same, except that `trim` and `silent` default to `
 Example usage:
 
 ```js
-promptly.password('Type a password: ', function (err, value) {
+promptly.password('Type a password: ', { replace: '*' }, function (err, value) {
     console.log('Password is:', value);
 });
 ```

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ function prompt(message, opts, fn) {
         prompt: message,
         input: opts.input || process.stdin,
         output: opts.output || process.stdout,
-        silent: opts.silent
+        silent: opts.silent,
+        replace: opts.replace || ''
     };
 
     // Use readline question


### PR DESCRIPTION
When I call `promptly.password`,  what I type isn't printed in the screen because `silent` is true. So I add a new option: `replace`. When I type a password,  it will replace each character with the specified string. For example, you can show `******` if `replace` is `*`.

I just add one line:
```
var readOpts = {
  ...,
  replace: opts.replace || ''
};
```

When calling `read(readOpts, callback)`, `readOpts.replace` will be used when `silent` is true.

